### PR TITLE
Prevent stat container stretching due to grid

### DIFF
--- a/layouts/about/impact.html
+++ b/layouts/about/impact.html
@@ -40,7 +40,7 @@
           </div>
         </section> 
 */}}
-        <section class="grid gap-10 lg:gap-20 md:grid-cols-2 section--lg">
+        <section class="grid gap-10 lg:gap-20 md:grid-cols-2 section--lg items-start">
           <div class="md:order-1 relative">
             {{ partial "image" (dict 
               "alt" "A plant growing in a pair of hands"
@@ -85,7 +85,7 @@
             </div>
           </div>
         </section>
-        <section class="grid gap-10 lg:gap-20 md:grid-cols-2 section--lg">
+        <section class="grid gap-10 lg:gap-20 md:grid-cols-2 section--lg items-start">
           <div class="relative">
             {{ partial "image" (dict 
               "alt" "A mostly submerged beaver."


### PR DESCRIPTION
Stats on the impact page are overlayed on images. The image container is stretching to match the height of the content next to it, so the stat isn't also shown in the right position. This fixes that issue

<img width="817" alt="Screenshot 2023-10-25 at 14 29 56" src="https://github.com/nternetinspired/madebykind-v3/assets/795907/93ebff05-9629-49a6-8d66-9aad6f07a16d">
